### PR TITLE
Fix citrix.xenserver.py issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ zbx_export_templates.xml --> contains both templates for VM and Host
 
 6. Set macros (Global on on all host you use this templates)
 
-{$XENMASTER} -->Masterserver of XENCLUSTER
+{$XENMASTER} --> Masterserver of XENCLUSTER
 
 {$XENUSERNAME} --> Username for connect to XENCLUSTER
 
@@ -34,7 +34,7 @@ Run the script as zabbix user from your zabbix or zabbix proxy host.
 
 Example:
 
-/usr/lib/zabbix/externalscripts/citrix.xenserver.py -m "<xenmaster>" -u "<xen/xcp root>" -p "<password>" -t "host" -H "<hostname>" -c "value" -f "memory_free_kib"
+/usr/lib/zabbix/externalscripts/citrix.xenserver.py -m "\<xenmaster>" -u "\<xen/xcp root>" -p "\<password>" -t "host" -H "\<hostname>" -c "value" -f "memory_free_kib"
 
 Check if you see data gathered from xenmaster in /tmp/xenapi.<hostname>... log files. 
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Installation notes
 1. XenAPi attached to repo, was taken from: https://github.com/xapi-project/xen-api/tree/master/scripts/examples/python.
 
 2. Copy file XENApi.py to directory /usr/local/lib/python3.9 (or similar existing) to the zabbix host or the zabbix proxy host.
+
 If you want to change, please change line sys.path.append('/usr/local/lib/python3.9') to sys.path.append('<yourpath>') on line 98 also!
 
-
 3. Copy citrix.xenserver.py from this repository to you externel script path and set userrights (chmod 755).
+
 Default is /usr/lib/zabbix/externalscripts to the zabbix host or the zabbix proxy host.
 
 4. Remember that script will be run as zabbix user not the root.
@@ -21,15 +22,20 @@ zbx_export_templates.xml --> contains both templates for VM and Host
 ### Please note, the the name in zabbix and the name in xen have to be the same!
 
 6. Set macros (Global on on all host you use this templates)
+
 {$XENMASTER} -->Masterserver of XENCLUSTER
+
 {$XENUSERNAME} --> Username for connect to XENCLUSTER
+
 {$XENPASSWORD} --> Password for connect to XENCLUSTER
 
 7. Troubleshooting:
 Run the script as zabbix user from your zabbix or zabbix proxy host.
 
 Example:
+
 /usr/lib/zabbix/externalscripts/citrix.xenserver.py -m "<xenmaster>" -u "<xen/xcp root>" -p "<password>" -t "host" -H "<hostname>" -c "value" -f "memory_free_kib"
 
 Check if you see data gathered from xenmaster in /tmp/xenapi.<hostname>... log files. 
+
 There should be 3 per hostname. 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,29 @@ Installation notes
 
 1. XenAPi attached to repo, was taken from: https://github.com/xapi-project/xen-api/tree/master/scripts/examples/python.
 
-2. Copy file XENApi.py to directory /usr/local/lib/python3.4 (or similar existing)
-
-If you want to change, please change line sys.path.append('/usr/local/lib/python') to sys.path.append('<yourpath') on line 98 also!
+2. Copy file XENApi.py to directory /usr/local/lib/python3.9 (or similar existing) to the zabbix host or the zabbix proxy host.
+If you want to change, please change line sys.path.append('/usr/local/lib/python3.9') to sys.path.append('<yourpath>') on line 98 also!
 
 
 3. Copy citrix.xenserver.py from this repository to you externel script path and set userrights (chmod 755).
-Default is /usr/lib/zabbix/externalscripts
+Default is /usr/lib/zabbix/externalscripts to the zabbix host or the zabbix proxy host.
 
-4. Import the templates
+4. Remember that script will be run as zabbix user not the root.
+
+5. Import the templates
 zbx_export_templates.xml --> contains both templates for VM and Host
-
 ### Please note, the the name in zabbix and the name in xen have to be the same!
 
- 
-
-5. Set macros (Global on on all host you use this templates)
-
+6. Set macros (Global on on all host you use this templates)
 {$XENMASTER} -->Masterserver of XENCLUSTER
-
 {$XENUSERNAME} --> Username for connect to XENCLUSTER
-
 {$XENPASSWORD} --> Password for connect to XENCLUSTER
+
+7. Troubleshooting:
+Run the script as zabbix user from your zabbix or zabbix proxy host.
+
+Example:
+/usr/lib/zabbix/externalscripts/citrix.xenserver.py -m "<xenmaster>" -u "<xen/xcp root>" -p "<password>" -t "host" -H "<hostname>" -c "value" -f "memory_free_kib"
+
+Check if you see data gathered from xenmaster in /tmp/xenapi.<hostname>... log files. 
+There should be 3 per hostname. 

--- a/citrix.xenserver.py
+++ b/citrix.xenserver.py
@@ -1,10 +1,12 @@
-#!/usr/bin/python3.4
+#!/usr/bin/python3.9
 """
 Autor:      Robert Gladewitz
-Change Autor: Daniel Bośnjak
-Version :   1.1
-Change:     28. March 2018
-
+Change Autor: Daniel Bośnjak, Kamil Seweryn
+Version :   1.1b
+Change:     05 May 2023
+Change info: 
+    1. [bug fix] added separate log files for each/based on the host name 
+    2. changed interpreter to python3.9 - currently used on Debian 11
 
 Description
 This script is based on XENApi, You can query performance counter for zabbix as external script.
@@ -96,7 +98,7 @@ Path where the XENApi is located.
 """
 ssl._create_default_https_context = ssl._create_unverified_context
 
-sys.path.append('/usr/local/lib/python3.4')
+sys.path.append('/usr/local/lib/python3.9')
 import XenAPI
 """
 #################################################################################################################################
@@ -473,7 +475,10 @@ def main(argv):
             type = arg
         elif opt == '-H':
             host = arg
-
+            temphostfile = "/tmp/xenapi." + host + ".hostperformance.tmp"
+            tempvmfile   = "/tmp/xenapi." + host + ".vmperformance.tmp"
+            tempsrfile   = "/tmp/xenapi." + host + ".srlist.tmp"
+            
     if (xenmaster == '' or username == '' or password == '' or command == '' or filter == '' or type == '' or host == '' ):
         print (sys.argv[0], " -m <master> -u <username> -p <password> -c <command> -f <filter> -t <host|vm> -H <hostname|vmname> [-a <maxage>] (Parameter missing)")
         sys.exit(3)


### PR DESCRIPTION
Hey there. I like your work on this but it did not work on for me out of the box.
I have found that the script is working for the first host I test it on and then it fails until I remove temp tiles even though running it from zabbix user. 

1. That is why I have added temp file creation for each host which makes it work and make sense for many hosts I am running it on simultaneously.
2. I have also changed the default interpreter to python3.9 - default one for Debian 11 I am running it on.
3. I have refreshed the README file and added troubleshooting portion with usage example to make it easier for new users.

If you find it sensible pull this to your master branch.
Greets Kamil "meekser"